### PR TITLE
fix(auth): 修正 Google 第三方登入流程與錯誤處理

### DIFF
--- a/migrations/V1__tripeasy_sql.sql
+++ b/migrations/V1__tripeasy_sql.sql
@@ -29,7 +29,8 @@ CREATE TABLE "socialLogin" (
     provider_token VARCHAR(255)  NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES "user"(user_id)
+    FOREIGN KEY (user_id) REFERENCES "user"(user_id),
+    UNIQUE (user_id, provider_method)
 );
 
 


### PR DESCRIPTION
此提交主要解決了 Google 第三方登入流程中的兩個核心問題：

1.  **修正帳號關聯邏輯**：
    先前的實作無法正確處理「已用 Email 註冊的用戶，首次用 Google 登入」的情境。此版本修改了 `post_user_LoginGoogle` 控制器，現在能夠正確地為已存在的用戶建立 `socialLogin` 關聯紀錄。

2.  **提升安全穩定性**：
    - 在 `postuserLoginGoogle` 中介軟體中增加了 `try...catch` 區塊，以捕捉來自 Google API 的錯誤，防止因未處理的 `axios` 錯誤而導致伺服器崩潰。
    - 修正了 `socialLogin` 資料表的結構，在 `(user_id, provider_method)` 上增加了唯一性約束，以支援 `ON CONFLICT` 功能並確保資料的完整性。

經過這些修改，Google 登入流程現在更加穩定、可靠，並且能夠正確處理各種使用者情境。